### PR TITLE
Add Homebrew "tap command" support

### DIFF
--- a/bin/brewdle
+++ b/bin/brewdle
@@ -1,7 +1,13 @@
 #!/usr/bin/env ruby
 
 require 'brewdler'
-require 'commander/import'
+
+begin
+  require 'commander/import'
+rescue LoadError
+  Brewdler::Commands::Install.run
+  exit
+end
 
 program :version, Brewdler::VERSION
 program :description, 'CLI helper for brewdler'

--- a/cmd/brew-brewdler.rb
+++ b/cmd/brew-brewdler.rb
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+BREWDLER_ROOT = File.expand_path "#{File.dirname(__FILE__)}/.."
+ENV["RUBYLIB"] = "#{BREWDLER_ROOT}/lib:#{ENV["RUBYLIB"]}"
+exec "#{BREWDLER_ROOT}/bin/brewdle"

--- a/lib/brewdler/commands/install.rb
+++ b/lib/brewdler/commands/install.rb
@@ -16,7 +16,7 @@ module Brewdler::Commands
   private
 
     def self.brewfile
-      File.read(Dir['{*,.*}{B,b}rewfile'].first)
+      File.read(Dir['{*,.*}{B,b}rewfile'].first.to_s)
     end
   end
 end


### PR DESCRIPTION
If this repo is renamed to e.g. `andrew/homebrew-brewdler` (or `Homebrew/homebrew-bundler` or whatever) then with this PR merged one will be able to:
```bash
brew tap mikemcquaid/brewdler # currently working but could instead be andrew/brewdler or Homebrew/bundler or whatever.
brew brewdler
```

The previous `gem` installation method will still work and this will just provide an alternate installation method that doesn't require any messing with `PATH`, any use of `gem` and autoupdates with `brew update`.

The implementation is still a bit hacky as-is so feel free to request I change the approach here and I'm happy to do so.